### PR TITLE
add `write_env` adaptor

### DIFF
--- a/include/ustdex/detail/completion_signatures.hpp
+++ b/include/ustdex/detail/completion_signatures.hpp
@@ -16,8 +16,7 @@
 #pragma once
 
 #include "cpos.hpp"
-
-#include <exception>
+#include "exception.hpp"
 
 namespace ustdex {
   template <class... Ts>

--- a/include/ustdex/detail/continue_on.hpp
+++ b/include/ustdex/detail/continue_on.hpp
@@ -79,7 +79,7 @@ namespace ustdex {
       }
     };
 
-    template <class CvSndr, class Sch, class Rcvr>
+    template <class Rcvr, class CvSndr, class Sch>
     struct _opstate_t {
       using operation_state_concept = operation_state_t;
       using _result_t = _transform_completion_signatures<
@@ -193,26 +193,26 @@ namespace ustdex {
       }
 
       template <class Query>
-      USTDEX_HOST_DEVICE auto
-        query(Query) const -> _query_result_t<Query, env_of_t<Sndr>> {
+      USTDEX_HOST_DEVICE auto query(Query) const //
+        -> _query_result_t<Query, env_of_t<Sndr>> {
         return ustdex::get_env(_sndr->_sndr).query(Query{});
       }
     };
 
     template <class... Env>
-    auto get_completion_signatures(const Env &...) && -> _completions<Sndr, Sch, Env...>;
+    auto get_completion_signatures(Env &&...) && -> _completions<Sndr, Sch, Env...>;
 
     template <class... Env>
-    auto get_completion_signatures(const Env &...) const & //
+    auto get_completion_signatures(Env &&...) const & //
       -> _completions<const Sndr &, Sch, Env...>;
 
     template <class Rcvr>
-    USTDEX_HOST_DEVICE _opstate_t<Sndr, Sch, Rcvr> connect(Rcvr rcvr) && {
+    USTDEX_HOST_DEVICE _opstate_t<Rcvr, Sndr, Sch> connect(Rcvr rcvr) && {
       return {static_cast<Sndr &&>(_sndr), _sch, static_cast<Rcvr &&>(rcvr)};
     }
 
     template <class Rcvr>
-    USTDEX_HOST_DEVICE _opstate_t<const Sndr &, Sch, Rcvr> connect(Rcvr rcvr) const & {
+    USTDEX_HOST_DEVICE _opstate_t<Rcvr, const Sndr &, Sch> connect(Rcvr rcvr) const & {
       return {_sndr, _sch, static_cast<Rcvr &&>(rcvr)};
     }
 

--- a/include/ustdex/detail/env.hpp
+++ b/include/ustdex/detail/env.hpp
@@ -25,15 +25,15 @@ namespace ustdex {
 
   USTDEX_DEVICE constexpr struct get_env_t {
     template <class Ty>
-    USTDEX_INLINE USTDEX_HOST_DEVICE auto
-      operator()(const Ty &ty) const noexcept -> decltype(ty.get_env()) {
+    USTDEX_INLINE USTDEX_HOST_DEVICE auto operator()(Ty &&ty) const noexcept //
+      -> decltype(ty.get_env()) {
       static_assert(noexcept(ty.get_env()));
       return ty.get_env();
     }
 
-    template <class Ty>
-    USTDEX_INLINE USTDEX_HOST_DEVICE auto
-      operator()(const Ty *ty) const noexcept -> decltype(ty->get_env()) {
+    template <class Self = get_env_t, template <class...> class Op, class Rcvr, class... Ts>
+    USTDEX_INLINE USTDEX_HOST_DEVICE auto operator()(Op<Rcvr, Ts...> *ty) const noexcept //
+      -> _call_result_t<Self, Rcvr> {
       static_assert(noexcept(ty->get_env()));
       return ty->get_env();
     }
@@ -54,4 +54,43 @@ namespace ustdex {
 
   template <class Ty>
   using env_of_t = decltype(get_env(DECLVAL(Ty)));
+
+  template <class Env1, class Env2>
+  struct _env_pair_t : _immovable {
+    Env1 _env;
+    Env2 (*const _get_env2)(const _env_pair_t *) noexcept;
+
+    template <class Query>
+    USTDEX_HOST_DEVICE auto query(Query) const          //
+      noexcept(_nothrow_queryable<const Env1 &, Query>) //
+      -> _query_result_t<Query, const Env1 &> {
+      return _env.query(Query{});
+    }
+
+    // The volatile here is to create an ordering between the two `query`
+    // overloads. The non-volatile overload will be prefered when both
+    // environments have the query.
+    template <class Query>
+    USTDEX_HOST_DEVICE auto query(Query) const volatile //
+      noexcept(_nothrow_queryable<Env2, Query>)         //
+      -> _query_result_t<Query, Env2> {
+      return _get_env2(this).query(Query{});
+    }
+  };
+
+  template <class Env, class Rcvr>
+  struct _env_rcvr_t : _env_pair_t<Env, env_of_t<Rcvr>> {
+    using _env_pair = _env_pair_t<Env, env_of_t<Rcvr>>;
+    Rcvr _rcvr;
+
+    static env_of_t<Rcvr> _get_env2(const _env_pair *self) noexcept {
+      return ustdex::get_env(static_cast<const _env_rcvr_t *>(self)->_rcvr);
+    }
+
+    USTDEX_HOST_DEVICE _env_rcvr_t(Env env, Rcvr rcvr)
+      : _env_pair{{}, static_cast<Env &&>(env), &_get_env2}
+      , _rcvr(static_cast<Rcvr &&>(rcvr)) {
+    }
+  };
+
 } // namespace ustdex

--- a/include/ustdex/detail/lazy.hpp
+++ b/include/ustdex/detail/lazy.hpp
@@ -31,7 +31,8 @@ namespace ustdex {
     }
 
     template <class... Ts>
-    USTDEX_HOST_DEVICE Ty &construct(Ts &&...ts) noexcept(_nothrow_constructible<Ty, Ts...>) {
+    USTDEX_HOST_DEVICE Ty &
+      construct(Ts &&...ts) noexcept(_nothrow_constructible<Ty, Ts...>) {
       ::new (static_cast<void *>(std::addressof(value))) Ty(static_cast<Ts &&>(ts)...);
       return value;
     }

--- a/include/ustdex/detail/let_value.hpp
+++ b/include/ustdex/detail/let_value.hpp
@@ -86,7 +86,7 @@ namespace ustdex {
     /// completes.
     /// @tparam Rcvr The receiver connected to the `let_(value|error|stopped)`
     /// sender.
-    template <class CvSndr, class Fn, class Rcvr>
+    template <class Rcvr, class CvSndr, class Fn>
     struct _opstate_t {
       using operation_state_concept = operation_state_t;
       Rcvr _rcvr;
@@ -146,7 +146,7 @@ namespace ustdex {
         _complete(set_stopped_t());
       }
 
-      USTDEX_HOST_DEVICE auto get_env() const noexcept {
+      USTDEX_HOST_DEVICE env_of_t<Rcvr> get_env() const noexcept {
         return ustdex::get_env(_rcvr);
       }
     };
@@ -213,35 +213,35 @@ namespace ustdex {
       Sndr _sndr;
 
       template <class... Env>
-      auto get_completion_signatures(const Env &...) && //
+      auto get_completion_signatures(Env &&...) && //
         -> _completions<Sndr, Fn, Env...>;
 
       template <class... Env>
-      auto get_completion_signatures(const Env &...) const & //
+      auto get_completion_signatures(Env &&...) const & //
         -> _completions<const Sndr &, Fn, Env...>;
 
       template <class Rcvr>
-      USTDEX_HOST_DEVICE auto connect(Rcvr &&rcvr) && noexcept(
-        _nothrow_constructible<_opstate_t<Sndr, Fn, Rcvr>, Sndr, Fn, Rcvr>)
-        -> _opstate_t<Sndr, Fn, Rcvr> {
-        return _opstate_t<Sndr, Fn, Rcvr>(
+      USTDEX_HOST_DEVICE auto connect(Rcvr rcvr) && noexcept(
+        _nothrow_constructible<_opstate_t<Rcvr, Sndr, Fn>, Sndr, Fn, Rcvr>)
+        -> _opstate_t<Rcvr, Sndr, Fn> {
+        return _opstate_t<Rcvr, Sndr, Fn>(
           static_cast<Sndr &&>(_sndr),
           static_cast<Fn &&>(_fn),
           static_cast<Rcvr &&>(rcvr));
       }
 
       template <class Rcvr>
-      USTDEX_HOST_DEVICE auto connect(Rcvr &&rcvr) const & noexcept( //
+      USTDEX_HOST_DEVICE auto connect(Rcvr rcvr) const & noexcept( //
         _nothrow_constructible<
-          _opstate_t<const Sndr &, Fn, Rcvr>,
+          _opstate_t<Rcvr, const Sndr &, Fn>,
           const Sndr &,
           const Fn &,
           Rcvr>) //
-        -> _opstate_t<const Sndr &, Fn, Rcvr> {
-        return _opstate_t<const Sndr &, Fn, Rcvr>(_sndr, _fn, static_cast<Rcvr &&>(rcvr));
+        -> _opstate_t<Rcvr, const Sndr &, Fn> {
+        return _opstate_t<Rcvr, const Sndr &, Fn>(_sndr, _fn, static_cast<Rcvr &&>(rcvr));
       }
 
-      USTDEX_HOST_DEVICE decltype(auto) get_env() const noexcept {
+      USTDEX_HOST_DEVICE env_of_t<Sndr> get_env() const noexcept {
         return ustdex::get_env(_sndr);
       }
     };

--- a/include/ustdex/detail/queries.hpp
+++ b/include/ustdex/detail/queries.hpp
@@ -24,7 +24,13 @@
 
 namespace ustdex {
   template <class Query, class Ty>
-  using _query_result_t = decltype(DECLVAL(Ty).query(Query()));
+  auto _query_result_() -> decltype(DECLVAL(Ty).query(Query()));
+
+  template <class Query, class Ty>
+  using _query_result_t = decltype(_query_result_<Query, Ty>());
+
+  template <class Query, class Ty>
+  USTDEX_DEVICE constexpr bool _has_query = _mvalid_q<_query_result_t, Query, Ty>;
 
   USTDEX_DEVICE constexpr struct get_allocator_t {
     template <class Env>

--- a/include/ustdex/detail/read_env.hpp
+++ b/include/ustdex/detail/read_env.hpp
@@ -18,10 +18,9 @@
 #include "config.hpp"
 #include "cpos.hpp"
 #include "env.hpp"
+#include "exception.hpp"
 #include "queries.hpp"
 #include "utility.hpp"
-
-#include <exception>
 
 namespace ustdex {
   struct THE_CURRENT_ENVIRONMENT_LACKS_THIS_QUERY;
@@ -48,7 +47,7 @@ namespace ustdex {
           set_error_t(std::exception_ptr)>>;
     };
 
-    template <class Query, class Rcvr>
+    template <class Rcvr, class Query>
     struct opstate_t {
       using operation_state_concept = operation_state_t;
       Rcvr _rcvr;
@@ -98,7 +97,7 @@ namespace ustdex {
     USTDEX_NO_UNIQUE_ADDRESS Query _query;
 
     template <class Env>
-    auto get_completion_signatures(const Env &) const //
+    auto get_completion_signatures(Env &&) const //
       -> _minvoke<
         _mif<_callable<Query, Env>, _completions_fn, _error_env_lacks_query<Query, Env>>,
         Query,
@@ -106,8 +105,8 @@ namespace ustdex {
 
     template <class Rcvr>
     USTDEX_HOST_DEVICE auto connect(Rcvr rcvr) const noexcept(_nothrow_movable<Rcvr>)
-      -> opstate_t<Query, Rcvr> {
-      return opstate_t<Query, Rcvr>{static_cast<Rcvr &&>(rcvr)};
+      -> opstate_t<Rcvr, Query> {
+      return opstate_t<Rcvr, Query>{static_cast<Rcvr &&>(rcvr)};
     }
   };
 

--- a/include/ustdex/detail/run_loop.hpp
+++ b/include/ustdex/detail/run_loop.hpp
@@ -22,10 +22,10 @@
 
 #  include "completion_signatures.hpp"
 #  include "env.hpp"
+#  include "exception.hpp"
 #  include "queries.hpp"
 
 #  include <condition_variable>
-#  include <exception>
 #  include <mutex>
 #  include <utility>
 
@@ -93,16 +93,15 @@ namespace ustdex {
         using _id = _schedule_task;
         using sender_concept = sender_t;
 
-        template <class... Env>
-        auto get_completion_signatures(const Env &...) const //
+        auto get_completion_signatures(_ignore_t = {}) const //
           -> completion_signatures<
             set_value_t(),
             set_error_t(std::exception_ptr),
             set_stopped_t()>;
 
         template <class Rcvr>
-        USTDEX_HOST_DEVICE auto connect(Rcvr _rcvr) const noexcept -> _operation<Rcvr> {
-          return {&_loop->_head, _loop, static_cast<Rcvr &&>(_rcvr)};
+        USTDEX_HOST_DEVICE auto connect(Rcvr rcvr) const noexcept -> _operation<Rcvr> {
+          return {&_loop->_head, _loop, static_cast<Rcvr &&>(rcvr)};
         }
 
        private:

--- a/include/ustdex/detail/sync_wait.hpp
+++ b/include/ustdex/detail/sync_wait.hpp
@@ -20,11 +20,11 @@
 // run_loop isn't supported on-device yet, so neither can sync_wait be.
 #ifndef USTDEX_CUDA
 
+#  include "exception.hpp"
 #  include "meta.hpp"
 #  include "run_loop.hpp"
 #  include "utility.hpp"
 
-#  include <exception>
 #  include <optional>
 #  include <system_error>
 #  include <tuple>

--- a/include/ustdex/detail/when_all.hpp
+++ b/include/ustdex/detail/when_all.hpp
@@ -430,8 +430,9 @@ namespace ustdex {
         return _data->_stop_token;
       }
 
-      template <class Tag, class Env = env_of_t<Rcvr>>
-      USTDEX_HOST_DEVICE auto query(Tag) const noexcept -> _query_result_t<Tag, Env> {
+      template <class Tag>
+      USTDEX_HOST_DEVICE auto
+        query(Tag) const noexcept -> _query_result_t<Tag, env_of_t<Rcvr>> {
         return ustdex::get_env(_data->_rcvr).query(Tag());
       }
     };
@@ -493,8 +494,8 @@ namespace ustdex {
     };
 
     /// The operation state for when_all
-    template <class CvFn, std::size_t... Idx, class... Sndrs, class Rcvr>
-    struct _opstate_t<CvFn, _tupl<std::index_sequence<Idx...>, Sndrs...>, Rcvr> {
+    template <class Rcvr, class CvFn, std::size_t... Idx, class... Sndrs>
+    struct _opstate_t<Rcvr, CvFn, _tupl<std::index_sequence<Idx...>, Sndrs...>> {
       using operation_state_concept = operation_state_t;
       using _sndrs_t = _minvoke<CvFn, _tuple<Sndrs...>>;
       using _env_t = env_of_t<Rcvr>;
@@ -582,23 +583,23 @@ namespace ustdex {
     _sndrs_t _sndrs;
 
     template <class... Env>
-    auto get_completion_signatures(const Env &...) && //
+    auto get_completion_signatures(Env &&...) && //
       -> _completions<_cp, Env...>;
 
     template <class... Env>
-    auto get_completion_signatures(const Env &...) const & //
+    auto get_completion_signatures(Env &&...) const & //
       -> _completions<_cpclr, Env...>;
 
     template <class Rcvr>
-    USTDEX_HOST_DEVICE auto connect(Rcvr rcvr) && -> _opstate_t<_cp, _sndrs_t, Rcvr> {
-      return _opstate_t<_cp, _sndrs_t, Rcvr>(
+    USTDEX_HOST_DEVICE auto connect(Rcvr rcvr) && -> _opstate_t<Rcvr, _cp, _sndrs_t> {
+      return _opstate_t<Rcvr, _cp, _sndrs_t>(
         static_cast<_sndrs_t &&>(_sndrs), static_cast<Rcvr &&>(rcvr));
     }
 
     template <class Rcvr>
     USTDEX_HOST_DEVICE auto connect(Rcvr rcvr) const & //
-      -> _opstate_t<_cpclr, _sndrs_t, Rcvr> {
-      return _opstate_t<_cpclr, _sndrs_t, Rcvr>(_sndrs, static_cast<Rcvr &&>(rcvr));
+      -> _opstate_t<Rcvr, _cpclr, _sndrs_t> {
+      return _opstate_t<Rcvr, _cpclr, _sndrs_t>(_sndrs, static_cast<Rcvr &&>(rcvr));
     }
   };
 

--- a/include/ustdex/detail/write_env.hpp
+++ b/include/ustdex/detail/write_env.hpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2024 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "config.hpp"
+#include "cpos.hpp"
+#include "env.hpp"
+#include "exception.hpp"
+#include "queries.hpp"
+#include "utility.hpp"
+
+namespace ustdex {
+  struct write_env_t {
+#ifndef __CUDACC__
+   private:
+#endif
+    template <class Rcvr, class Env>
+    struct _rcvr_t {
+      using receiver_concept = receiver_t;
+      _env_rcvr_t<Env, Rcvr> *_env_rcvr;
+
+      template <class... As>
+      USTDEX_HOST_DEVICE void set_value(As &&...as) noexcept {
+        ustdex::set_value(
+          static_cast<Rcvr &&>(_env_rcvr->_rcvr), static_cast<As &&>(as)...);
+      }
+
+      template <class Error>
+      USTDEX_HOST_DEVICE void set_value(Error &&error) noexcept {
+        ustdex::set_error(
+          static_cast<Rcvr &&>(_env_rcvr->_rcvr), static_cast<Error &&>(error));
+      }
+
+      USTDEX_HOST_DEVICE void set_stopped() noexcept {
+        ustdex::set_stopped(static_cast<Rcvr &&>(_env_rcvr->_rcvr));
+      }
+
+      USTDEX_HOST_DEVICE auto get_env() const noexcept //
+        -> const _env_pair_t<Env, env_of_t<Rcvr>> & {
+        return *_env_rcvr;
+      }
+    };
+
+    template <class Rcvr, class Sndr, class Env>
+    struct _opstate_t {
+      using operation_state_concept = operation_state_t;
+      _env_rcvr_t<Env, Rcvr> _env_rcvr;
+      connect_result_t<Sndr, _rcvr_t<Rcvr, Env>> _op;
+
+      USTDEX_HOST_DEVICE explicit _opstate_t(Sndr &&sndr, Env env, Rcvr rcvr)
+        : _env_rcvr(static_cast<Env &&>(env), static_cast<Rcvr &&>(rcvr))
+        , _op(
+            ustdex::connect(static_cast<Sndr &&>(sndr), _rcvr_t<Rcvr, Env>{&_env_rcvr})) {
+      }
+
+      USTDEX_IMMOVABLE(_opstate_t);
+
+      USTDEX_HOST_DEVICE void start() noexcept {
+        ustdex::start(_op);
+      }
+    };
+
+    template <class Sndr, class Env>
+    struct _sndr_t;
+
+   public:
+    /// @brief Wraps one sender in another that modifies the execution
+    /// environment by merging in the environment specified.
+    template <class Sndr, class Env>
+    USTDEX_HOST_DEVICE USTDEX_INLINE constexpr auto operator()(Sndr, Env) const //
+      -> _sndr_t<Sndr, Env>;
+  };
+
+  template <class Sndr, class Env>
+  struct write_env_t::_sndr_t {
+    using sender_concept = sender_t;
+    USTDEX_NO_UNIQUE_ADDRESS write_env_t _tag;
+    Env _env;
+    Sndr _sndr;
+
+    template <class OtherEnv>
+    using _env_t = const _env_pair_t<Env, OtherEnv> &;
+
+    template <class... OtherEnv>
+    auto get_completion_signatures(OtherEnv &&...) && //
+      -> completion_signatures_of_t<Sndr, _env_t<OtherEnv>...>;
+
+    template <class... OtherEnv>
+    auto get_completion_signatures(OtherEnv &&...) const & //
+      -> completion_signatures_of_t<const Sndr &, _env_t<OtherEnv>...>;
+
+    template <class Rcvr>
+    USTDEX_HOST_DEVICE auto connect(Rcvr rcvr) && //
+      -> _opstate_t<Rcvr, Sndr, Env> {
+      return _opstate_t<Rcvr, Sndr, Env>{
+        static_cast<Sndr &&>(_sndr),
+        static_cast<Env &&>(_env),
+        static_cast<Rcvr &&>(rcvr)};
+    }
+
+    template <class Rcvr>
+    USTDEX_HOST_DEVICE auto connect(Rcvr rcvr) const & //
+      -> _opstate_t<Rcvr, const Sndr &, Env> {
+      return _opstate_t<Rcvr, const Sndr &, Env>{_sndr, _env, static_cast<Rcvr &&>(rcvr)};
+    }
+
+    USTDEX_HOST_DEVICE env_of_t<Sndr> get_env() const noexcept {
+      return ustdex::get_env(_sndr);
+    }
+  };
+
+  template <class Sndr, class Env>
+  USTDEX_HOST_DEVICE USTDEX_INLINE constexpr auto
+    write_env_t::operator()(Sndr sndr, Env env) const //
+    -> write_env_t::_sndr_t<Sndr, Env> {
+    return write_env_t::_sndr_t<Sndr, Env>{
+      {}, static_cast<Env &&>(env), static_cast<Sndr &&>(sndr)};
+  }
+
+  USTDEX_DEVICE constexpr write_env_t write_env{};
+
+} // namespace ustdex

--- a/include/ustdex/ustdex.hpp
+++ b/include/ustdex/ustdex.hpp
@@ -29,3 +29,4 @@
 #include "detail/then.hpp"
 #include "detail/thread_context.hpp"
 #include "detail/when_all.hpp"
+#include "detail/write_env.hpp"

--- a/tests/common/error_scheduler.hpp
+++ b/tests/common/error_scheduler.hpp
@@ -22,7 +22,7 @@
 
 namespace {
   //! Scheduler that returns a sender that always completes with error.
-  template <typename Error>
+  template <class Error>
   struct error_scheduler {
    private:
     struct env_t {
@@ -36,7 +36,7 @@ namespace {
       }
     };
 
-    template <typename Rcvr>
+    template <class Rcvr>
     struct opstate_t : ustdex::_immovable {
       using operation_state_concept = ustdex::operation_state_t;
 
@@ -57,7 +57,7 @@ namespace {
           ustdex::set_error_t(Error),
           ustdex::set_stopped_t()>;
 
-      template <typename Rcvr>
+      template <class Rcvr>
       opstate_t<Rcvr> connect(Rcvr rcvr) const {
         return {{}, static_cast<Rcvr&&>(rcvr), _err};
       }

--- a/tests/common/stopped_scheduler.hpp
+++ b/tests/common/stopped_scheduler.hpp
@@ -35,7 +35,7 @@ namespace {
       }
     };
 
-    template <typename Rcvr>
+    template <class Rcvr>
     struct opstate_t : ustdex::_immovable {
       using operation_state_concept = ustdex::operation_state_t;
 
@@ -52,7 +52,7 @@ namespace {
       auto get_completion_signatures(ustdex::_ignore_t = {})
         -> ustdex::completion_signatures<ustdex::set_value_t(), ustdex::set_stopped_t()>;
 
-      template <typename Rcvr>
+      template <class Rcvr>
       opstate_t<Rcvr> connect(Rcvr rcvr) const {
         return {{}, static_cast<Rcvr&&>(rcvr)};
       }


### PR DESCRIPTION
also:

* fixes a problem with using opstate ptrs as receivers
* avoids duplicated completion signature computation by using differently typed environments in `connect` and `get_completion_signatures`.