### PR TITLE
improve the meta-programming of completion signatures to instantiate fewer templates

### DIFF
--- a/include/ustdex/detail/basic_sender.hpp
+++ b/include/ustdex/detail/basic_sender.hpp
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2024 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "config.hpp"
+
+#include "completion_signatures.hpp"
+#include "cpos.hpp"
+#include "utility.hpp"
+
+namespace ustdex {
+  template <class Data, class Rcvr>
+  struct state {
+    Data data;
+    Rcvr receiver;
+  };
+
+  struct receiver_defaults {
+    using receiver_concept = ustdex::receiver_t;
+
+    template <class Rcvr, class... Args>
+    USTDEX_HOST_DEVICE USTDEX_INLINE static auto
+      set_value(_ignore, Rcvr& rcvr, Args&&... args) noexcept
+      -> ustdex::completion_signatures<ustdex::set_value_t(Args...)> {
+      ustdex::set_value(std::move(rcvr), (Args&&) args...);
+      return {};
+    }
+
+    template <class Rcvr, class Error>
+    USTDEX_HOST_DEVICE USTDEX_INLINE static auto
+      set_error(_ignore, Rcvr& rcvr, Error&& err) noexcept
+      -> ustdex::completion_signatures<ustdex::set_error_t(Error)> {
+      ustdex::set_error(std::move(rcvr), (Error&&) err);
+      return {};
+    }
+
+    template <class Rcvr>
+    USTDEX_HOST_DEVICE USTDEX_INLINE static auto
+      set_stopped(_ignore, Rcvr& rcvr) noexcept
+      -> ustdex::completion_signatures<ustdex::set_stopped_t()> {
+      ustdex::set_stopped(std::move(rcvr));
+      return {};
+    }
+
+    template <class Rcvr>
+    USTDEX_HOST_DEVICE USTDEX_INLINE static decltype(auto)
+      get_env(_ignore, const Rcvr& rcvr) noexcept {
+      return ustdex::get_env(rcvr);
+    }
+  };
+
+  template <class Data, class Rcvr>
+  struct basic_receiver {
+    using receiver_concept = ustdex::receiver_t;
+    using _rcvr_t = typename Data::receiver_tag;
+    state<Data, Rcvr>& state_;
+
+    template <class... Args>
+    USTDEX_HOST_DEVICE USTDEX_INLINE void set_value(Args&&... args) noexcept {
+      _rcvr_t::set_value(state_.data, state_.receiver, (Args&&) args...);
+    }
+
+    template <class Error>
+    USTDEX_HOST_DEVICE USTDEX_INLINE void set_error(Error&& err) noexcept {
+      _rcvr_t::set_error(state_.data, state_.receiver, (Error&&) err);
+    }
+
+    USTDEX_HOST_DEVICE USTDEX_INLINE void set_stopped() noexcept {
+      _rcvr_t::set_stopped(state_.data, state_.receiver);
+    }
+
+    USTDEX_HOST_DEVICE USTDEX_INLINE decltype(auto) get_env() const noexcept {
+      return _rcvr_t::get_env(state_.data, state_.receiver);
+    }
+  };
+
+  template <class Rcvr>
+  inline constexpr bool has_no_environment = USTDEX_IS_SAME(Rcvr, receiver_archetype);
+
+  template <bool HasStopped, class Data, class Rcvr>
+  struct _mk_completions {
+    using _rcvr_t = typename Data::receiver_tag;
+
+    template <class... Args>
+    using _set_value_t = decltype(+*_rcvr_t::set_value(
+      std::declval<Data&>(),
+      std::declval<receiver_archetype&>(),
+      std::declval<Args>()...));
+
+    template <class Error>
+    using _set_error_t = decltype(+*_rcvr_t::set_error(
+      std::declval<Data&>(),
+      std::declval<receiver_archetype&>(),
+      std::declval<Error>()));
+
+    using _set_stopped_t = ustdex::completion_signatures<>;
+  };
+
+  template <class Data, class Rcvr>
+  struct _mk_completions<true, Data, Rcvr> : _mk_completions<false, Data, Rcvr> {
+    using _rcvr_t = typename Data::receiver_tag;
+
+    using _set_stopped_t = decltype(+*_rcvr_t::set_stopped(
+      std::declval<Data&>(),
+      std::declval<receiver_archetype&>()));
+  };
+
+  template <class...>
+  using _ignore_value_signature = ustdex::completion_signatures<>;
+
+  template <class>
+  using _ignore_error_signature = ustdex::completion_signatures<>;
+
+  template <class Completions>
+  constexpr bool _has_stopped = !USTDEX_IS_SAME(
+    ustdex::completion_signatures<>,
+    ustdex::transform_completion_signatures<
+      Completions,
+      ustdex::completion_signatures<>,
+      _ignore_value_signature,
+      _ignore_error_signature>);
+
+  template <bool PotentiallyThrowing, class Rcvr>
+  void set_current_exception_if(Rcvr& rcvr) noexcept {
+    if constexpr (PotentiallyThrowing) {
+      ustdex::set_error(std::move(rcvr), std::current_exception());
+    }
+  }
+
+  // A generic type that holds the data for an async operation, and
+  // that provides a `start` method for enqueuing the work.
+  template <class Sndr, class Data, class Rcvr>
+  struct basic_opstate {
+    using _rcvr_t = basic_receiver<Data, Rcvr>;
+    using _completions_t = completion_signatures_of_t<Sndr, _rcvr_t>;
+    using _traits_t = _mk_completions<_has_stopped<_completions_t>, Data, Rcvr>;
+
+    using completion_signatures = transform_completion_signatures<
+      _completions_t,
+      ustdex::completion_signatures<>, // TODO
+      _traits_t::template _set_value_t,
+      _traits_t::template _set_error_t,
+      typename _traits_t::_set_stopped_t>;
+
+    USTDEX_HOST_DEVICE basic_opstate(Sndr&& sndr, Data data, Rcvr rcvr)
+      : state_{static_cast<Data&&>(data), static_cast<Rcvr&&>(rcvr)}
+      , op_(ustdex::connect(static_cast<Sndr&&>(sndr), _rcvr_t{state_})) {
+    }
+
+    USTDEX_HOST_DEVICE USTDEX_INLINE void start() noexcept {
+      ustdex::start(op_);
+    }
+
+    state<Data, Rcvr> state_;
+    ustdex::connect_result_t<Sndr, _rcvr_t> op_;
+  };
+
+  template <class Sndr, class Rcvr>
+  USTDEX_HOST_DEVICE USTDEX_INLINE auto _make_opstate(Sndr sndr, Rcvr rcvr) {
+    auto [tag, data, child] = std::move(sndr);
+    return basic_opstate(std::move(child), std::move(data), std::move(rcvr));
+  }
+
+  template <class Data, class... Sndrs>
+  USTDEX_HOST_DEVICE USTDEX_INLINE auto
+    _get_attrs(int, const Data& data, const Sndrs&... sndrs) noexcept
+    -> decltype(data.get_attrs(sndrs...)) {
+    return data.get_attrs(sndrs...);
+  }
+
+  template <class Data, class... Sndrs>
+  USTDEX_HOST_DEVICE USTDEX_INLINE auto
+    _get_attrs(long, const Data& data, const Sndrs&... sndrs) noexcept
+    -> decltype(ustdex::get_env(sndrs...)) {
+    return ustdex::get_env(sndrs...);
+  }
+
+  template <class Data, class... Sndrs>
+  struct basic_sender;
+
+  template <class Data, class Sndr>
+  struct basic_sender<Data, Sndr> {
+    using sender_concept = ustdex::sender_t;
+    using _tag_t = typename Data::sender_tag;
+    using _rcvr_t = typename Data::receiver_tag;
+
+    [[no_unique_address]] _tag_t _tag_;
+    Data data_;
+    Sndr sndr_;
+
+    // Connect the sender to the receiver (the continuation) and
+    // return the state_type object for this operation.
+    template <class Rcvr>
+    USTDEX_HOST_DEVICE USTDEX_INLINE auto connect(Rcvr rcvr) && {
+      return _make_opstate(std::move(*this), std::move(rcvr));
+    }
+
+    template <class Rcvr>
+    USTDEX_HOST_DEVICE USTDEX_INLINE auto connect(Rcvr rcvr) const & {
+      return _make_opstate(*this, std::move(rcvr));
+    }
+
+    USTDEX_HOST_DEVICE USTDEX_INLINE decltype(auto) get_env() const noexcept {
+      return ustdex::_get_attrs(0, data_, sndr_);
+    }
+  };
+
+  template <class Data, class... Sndrs>
+  basic_sender(_ignore, Data, Sndrs...) -> basic_sender<Data, Sndrs...>;
+
+} // namespace ustdex

--- a/include/ustdex/detail/completion_signatures.hpp
+++ b/include/ustdex/detail/completion_signatures.hpp
@@ -26,13 +26,13 @@ namespace ustdex {
   extern _undefined<Sig> _transform_sig;
 
   template <class... Values, template <class...> class V, template <class...> class E, class S>
-  extern V<Values...> (*_transform_sig<set_value_t(Values...), V, E, S>)();
+  extern _fn_t<V<Values...>>* _transform_sig<set_value_t(Values...), V, E, S>;
 
   template <class Error, template <class...> class V, template <class...> class E, class S>
-  extern E<Error> (*_transform_sig<set_error_t(Error), V, E, S>)();
+  extern _fn_t<E<Error>>* _transform_sig<set_error_t(Error), V, E, S>;
 
   template <template <class...> class V, template <class...> class E, class S>
-  extern S (*_transform_sig<set_stopped_t(), V, E, S>)();
+  extern _fn_t<S>* _transform_sig<set_stopped_t(), V, E, S>;
 
   template <class Sig, template <class...> class V, template <class...> class E, class S>
   using _transform_sig_t = decltype(_transform_sig<Sig, V, E, S>());
@@ -59,8 +59,8 @@ namespace ustdex {
     template <class...>
     class Variant,
     class... More>
-  extern ERROR<What...>
-    (*_transform_completion_signatures_v<ERROR<What...>, V, E, S, Variant, More...>)();
+  extern _fn_t<ERROR<What...>>*
+    _transform_completion_signatures_v<ERROR<What...>, V, E, S, Variant, More...>;
 
   template <
     class... Sigs,
@@ -72,14 +72,14 @@ namespace ustdex {
     template <class...>
     class Variant,
     class... More>
-  extern Variant<_transform_sig_t<Sigs, V, E, S>..., More...>
-    (*_transform_completion_signatures_v<
+  extern _fn_t<Variant<_transform_sig_t<Sigs, V, E, S>..., More...>>*
+    _transform_completion_signatures_v<
       completion_signatures<Sigs...>,
       V,
       E,
       S,
       Variant,
-      More...>)();
+      More...>;
 
   template <
     class Sigs,

--- a/include/ustdex/detail/sync_wait.hpp
+++ b/include/ustdex/detail/sync_wait.hpp
@@ -30,6 +30,39 @@
 #  include <tuple>
 
 namespace ustdex {
+  struct sync_wait_t;
+
+  namespace _detail {
+    template <bool>
+    struct _exactly_one {
+      template <class Tuple>
+      using _f = Tuple;
+    };
+
+    template <>
+    struct _exactly_one<false> {
+      template <class... Ts>
+      static auto _to_sig(std::tuple<Ts...>*) -> set_value_t (*)(Ts...);
+
+      template <class... Sigs>
+      static auto _collect(Sigs*...) -> WITH_COMPLETIONS<Sigs...>;
+
+      template <class... Tuples>
+      using _f = ERROR<
+        WHERE(IN_ALGORITHM, sync_wait_t),
+        WHAT(SENDER_HAS_TOO_MANY_SUCCESS_COMPLETIONS),
+        decltype(_collect(_to_sig((Tuples*) 0)...))>;
+    };
+  } // namespace _detail
+
+  namespace _sync_wait {
+    template <class>
+    static constexpr bool _ok = false;
+
+    template <class... Ts>
+    static constexpr bool _ok<std::tuple<Ts...>> = true;
+  } // namespace _sync_wait
+
   /// @brief Function object type for synchronously waiting for the result of a
   /// sender.
   struct sync_wait_t {
@@ -48,60 +81,59 @@ namespace ustdex {
       }
     };
 
-    template <class Sndr>
-    struct _state_t {
-      struct _rcvr_t {
-        using receiver_concept = receiver_t;
-        _state_t* _state;
-
-        template <class... As>
-        USTDEX_HOST_DEVICE void set_value(As&&... _as) noexcept {
-          USTDEX_TRY(
-            ({ //
-              _state->_values->emplace(static_cast<As&&>(_as)...);
-            }),                 //
-            USTDEX_CATCH(...)({ //
-              _state->_eptr = std::current_exception();
-            }))
-          _state->_loop.finish();
-        }
-
-        template <class Error>
-        USTDEX_HOST_DEVICE void set_error(Error _err) noexcept {
-          if constexpr (USTDEX_IS_SAME(Error, std::exception_ptr))
-            _state->_eptr = static_cast<Error&&>(_err);
-          else if constexpr (USTDEX_IS_SAME(Error, std::error_code))
-            _state->_eptr = std::make_exception_ptr(std::system_error(_err));
-          else
-            _state->_eptr = std::make_exception_ptr(static_cast<Error&&>(_err));
-          _state->_loop.finish();
-        }
-
-        USTDEX_HOST_DEVICE void set_stopped() noexcept {
-          _state->_loop.finish();
-        }
-
-        _env_t get_env() const noexcept {
-          return _env_t{&_state->_loop};
-        }
-      };
-
-      using _values_t = value_types_of_t<Sndr, _rcvr_t, std::tuple, _midentity::_f>;
-
-      std::optional<_values_t>* _values;
+    struct _rcvr_base {
       std::exception_ptr _eptr;
-      run_loop _loop;
+      mutable run_loop _loop;
+
+      _env_t get_env() const noexcept {
+        return _env_t{&_loop};
+      }
     };
 
+    template <class Tuple>
+    struct _rcvr : _rcvr_base {
+      using receiver_concept = receiver_t;
+
+      template <class... As>
+      USTDEX_HOST_DEVICE void set_value(As&&... _as) noexcept {
+        USTDEX_TRY(
+          ({ //
+            _values->emplace(static_cast<As&&>(_as)...);
+          }),                 //
+          USTDEX_CATCH(...)({ //
+            _eptr = std::current_exception();
+          }))
+        _loop.finish();
+      }
+
+      template <class Error>
+      USTDEX_HOST_DEVICE void set_error(Error _err) noexcept {
+        if constexpr (USTDEX_IS_SAME(Error, std::exception_ptr))
+          _eptr = static_cast<Error&&>(_err);
+        else if constexpr (USTDEX_IS_SAME(Error, std::error_code))
+          _eptr = std::make_exception_ptr(std::system_error(_err));
+        else
+          _eptr = std::make_exception_ptr(static_cast<Error&&>(_err));
+        _loop.finish();
+      }
+
+      USTDEX_HOST_DEVICE void set_stopped() noexcept {
+        _loop.finish();
+      }
+
+      std::optional<Tuple>* _values;
+    };
+
+    template <class... Tuples>
+    using _variant_t =
+      _mtry_invoke<_detail::_exactly_one<sizeof...(Tuples) == 1>, Tuples...>;
+
+    template <class Sndr, class Rcvr = _rcvr_base>
+    using _values_t = value_types_of_t<Sndr, Rcvr*, std::tuple, _variant_t>;
+
     struct _invalid_sync_wait {
-      const _invalid_sync_wait& value() const {
-        return *this;
-      }
-
-      const _invalid_sync_wait& operator*() const {
-        return *this;
-      }
-
+      const _invalid_sync_wait& value() const;
+      const _invalid_sync_wait& operator*() const;
       int i;
     };
 
@@ -133,28 +165,30 @@ namespace ustdex {
     // clang-format on
     template <class Sndr>
     auto operator()(Sndr&& sndr) const {
-      using _rcvr_t = typename _state_t<Sndr>::_rcvr_t;
-      using _values_t = typename _state_t<Sndr>::_values_t;
-      using _completions = completion_signatures_of_t<Sndr, _rcvr_t>;
-      static_assert(_is_completion_signatures<_completions>);
+      using _sync_wait::_ok;
+      using _vals_t = _values_t<Sndr>;
+      static_assert(_ok<_vals_t>);
 
-      if constexpr (!_is_completion_signatures<_completions>) {
+      // Avoid cascading errors by skipping the sync_wait logic if the sender
+      // has too many value completions, or is invalid in some other way.
+      if constexpr (!_ok<_vals_t>) {
         return _invalid_sync_wait{0};
       } else {
+        static_assert(USTDEX_IS_SAME(_vals_t, _values_t<Sndr, _rcvr<_vals_t>>));
 
-        std::optional<_values_t> result{};
-        _state_t<Sndr> state{&result};
+        std::optional<_vals_t> result{};
+        _rcvr<_vals_t> rcvr{{}, &result};
 
         // Launch the sender with a continuation that will fill in a variant
-        auto opstate = connect(static_cast<Sndr&&>(sndr), _rcvr_t{&state});
+        auto opstate = connect(static_cast<Sndr&&>(sndr), &rcvr);
         start(opstate);
 
         // Wait for the variant to be filled in, and process any work that
         // may be delegated to this thread.
-        state._loop.run();
+        rcvr._loop.run();
 
-        if (state._eptr)
-          std::rethrow_exception(state._eptr);
+        if (rcvr._eptr)
+          std::rethrow_exception(rcvr._eptr);
 
         return result; // uses NRVO to "return" the result
       }

--- a/include/ustdex/detail/utility.hpp
+++ b/include/ustdex/detail/utility.hpp
@@ -91,20 +91,22 @@ namespace ustdex {
 #if USTDEX_NVHPC() || USTDEX_EDG()
   // This version of _ref is for compilers that display the return
   // type of a monomorphic lambda in the compiler output.
-  inline constexpr auto _ref = [](auto &o) noexcept {
-    return [&o](auto &...p) noexcept -> decltype(auto) {
-      static_assert(sizeof...(p) == 0);
-      return (void(p), ..., (o));
+  inline constexpr auto _ref = [](auto fn) noexcept {
+    return [fn](auto...) noexcept -> decltype(auto) {
+      return fn;
     };
   };
 #else
-  inline constexpr auto _ref = [](auto &o) noexcept {
-    return [&o]() noexcept -> decltype(auto) {
-      return (o);
+  inline constexpr auto _ref = [](auto fn) noexcept {
+    return [fn]() noexcept -> decltype(auto) {
+      return fn;
     };
   };
 #endif
 
   template <class Ty>
-  using _ref_t = decltype(_ref(_declval<Ty &>()));
+  using _ref_t = decltype(_ref(static_cast<Ty (*)()>(nullptr)));
+
+  template <class Ref>
+  using _deref_t = decltype(_declval<Ref>()()());
 } // namespace ustdex

--- a/include/ustdex/ustdex.hpp
+++ b/include/ustdex/ustdex.hpp
@@ -16,6 +16,8 @@
 #pragma once
 
 #include "detail/config.hpp"
+
+#include "detail/basic_sender.hpp"
 #include "detail/continue_on.hpp"
 #include "detail/cpos.hpp"
 #include "detail/just.hpp"


### PR DESCRIPTION
also:

* add a `basic_sender` facade type
* improve diagnostics of `sync_wait`