### PR TITLE
add the `conditional` and `just_from` senders

### DIFF
--- a/examples/scratch.cpp
+++ b/examples/scratch.cpp
@@ -90,4 +90,18 @@ int main()
                        std::cout << "sequence sender 2\n";
                      }));
   sync_wait(std::move(s6));
+
+  auto s7 =
+    just(42)
+    | conditional(
+      [](int i) {
+        return i % 2 == 0;
+      },
+      then([](int) {
+        std::cout << "even\n";
+      }),
+      then([](int) {
+        std::cout << "odd\n";
+      }));
+  sync_wait(std::move(s7));
 }

--- a/include/ustdex/detail/completion_signatures.hpp
+++ b/include/ustdex/detail/completion_signatures.hpp
@@ -17,10 +17,25 @@
 
 namespace USTDEX_NAMESPACE
 {
+// A typelist for completion signatures
 template <class... Ts>
 struct completion_signatures
 {};
 
+// A metafunction to determine if a type is a completion signature
+template <class>
+inline constexpr bool _is_valid_signature = false;
+
+template <class... Ts>
+inline constexpr bool _is_valid_signature<set_value_t(Ts...)> = true;
+
+template <class Error>
+inline constexpr bool _is_valid_signature<set_error_t(Error)> = true;
+
+template <>
+inline constexpr bool _is_valid_signature<set_stopped_t()> = true;
+
+// The implementation of transform_completion_signatures starts here
 template <class Sig, template <class...> class V, template <class...> class E, class S>
 extern _undefined<Sig> _transform_sig;
 

--- a/include/ustdex/detail/conditional.hpp
+++ b/include/ustdex/detail/conditional.hpp
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2024 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "completion_signatures.hpp"
+#include "config.hpp"
+#include "just_from.hpp"
+#include "type_traits.hpp"
+#include "variant.hpp"
+
+namespace ustdex
+{
+struct _cond_t
+{
+  template <class Pred, class Then, class Else>
+  struct _data
+  {
+    Pred pred_;
+    Then then_;
+    Else else_;
+  };
+
+  template <class... Args>
+  static auto _mk_complete_fn(Args&&... args) noexcept
+  {
+    return [&](auto sink) noexcept {
+      return sink(static_cast<Args&&>(args)...);
+    };
+  }
+
+  template <class... Args>
+  using _just_from_t = decltype(just_from(_cond_t::_mk_complete_fn(DECLVAL(Args)...)));
+
+  template <class Sndr, class Rcvr, class Pred, class Then, class Else>
+  struct _opstate
+  {
+    using operation_state_concept = operation_state_t;
+
+    friend env_of_t<Rcvr> get_env(const _opstate* self) noexcept
+    {
+      return get_env(self->_rcvr);
+    }
+
+    template <class... Args>
+    using _value_t = //
+      transform_completion_signatures<
+        completion_signatures_of_t<_call_result_t<Then, _just_from_t<Args...>>, _rcvr_ref_t<Rcvr&>>,
+        completion_signatures_of_t<_call_result_t<Else, _just_from_t<Args...>>, _rcvr_ref_t<Rcvr&>>>;
+
+    template <class... Args>
+    using _opstate_t = //
+      _mlist< //
+        connect_result_t<_call_result_t<Then, _just_from_t<Args...>>, _rcvr_ref_t<Rcvr&>>,
+        connect_result_t<_call_result_t<Else, _just_from_t<Args...>>, _rcvr_ref_t<Rcvr&>>>;
+
+    using completion_signatures = //
+      transform_completion_signatures_of<Sndr, _opstate*, ustdex::completion_signatures<>, _value_t>;
+
+    _opstate(Sndr&& sndr, Rcvr&& rcvr, _data<Pred, Then, Else>&& data)
+        : _rcvr{static_cast<Rcvr&&>(rcvr)}
+        , _data{static_cast<_cond_t::_data<Pred, Then, Else>>(data)}
+        , _op{ustdex::connect(static_cast<Sndr&&>(sndr), this)}
+    {}
+
+    void start() noexcept
+    {
+      ustdex::start(_op);
+    }
+
+    template <class... Args>
+    void set_value(Args&&... args) noexcept
+    {
+      if (static_cast<Pred&&>(_data.pred_)(args...))
+      {
+        auto& op = _ops.emplace_from(
+          connect,
+          static_cast<Then&&>(_data.then_)(just_from(_cond_t::_mk_complete_fn(static_cast<Args&&>(args)...))),
+          _rcvr_ref(_rcvr));
+        ustdex::start(op);
+      }
+      else
+      {
+        auto& op = _ops.emplace_from(
+          connect,
+          static_cast<Else&&>(_data.else_)(just_from(_cond_t::_mk_complete_fn(static_cast<Args&&>(args)...))),
+          _rcvr_ref(_rcvr));
+        ustdex::start(op);
+      }
+    }
+
+    template <class Error>
+    void set_error(Error&& err) noexcept
+    {
+      ustdex::set_error(static_cast<Rcvr&&>(_rcvr), static_cast<Error&&>(err));
+    }
+
+    void set_stopped() noexcept
+    {
+      ustdex::set_stopped(static_cast<Rcvr&&>(_rcvr));
+    }
+
+    Rcvr _rcvr;
+    _cond_t::_data<Pred, Then, Else> _data;
+    connect_result_t<Sndr, _opstate*> _op;
+    _value_types<completion_signatures_of_t<Sndr, _opstate*>, _opstate_t, _mconcat_into_q<_variant>::_f> _ops;
+  };
+
+  template <class Sndr, class Pred, class Then, class Else>
+  struct _sndr;
+
+  template <class Pred, class Then, class Else>
+  struct _closure
+  {
+    _cond_t::_data<Pred, Then, Else> _data;
+
+    template <class Sndr>
+    USTDEX_HOST_DEVICE USTDEX_INLINE auto _mk_sender(Sndr&& sndr) //
+      -> _sndr<Sndr, Pred, Then, Else>;
+
+    template <class Sndr>
+    USTDEX_HOST_DEVICE USTDEX_INLINE auto operator()(Sndr sndr) //
+      -> _sndr<Sndr, Pred, Then, Else>
+    {
+      return _mk_sender(std::move(sndr));
+    }
+
+    template <class Sndr>
+    USTDEX_HOST_DEVICE USTDEX_INLINE friend auto operator|(Sndr sndr, _closure&& _self) //
+      -> _sndr<Sndr, Pred, Then, Else>
+    {
+      return _self._mk_sender(std::move(sndr));
+    }
+  };
+
+  template <class Sndr, class Pred, class Then, class Else>
+  USTDEX_HOST_DEVICE USTDEX_INLINE auto operator()(Sndr sndr, Pred pred, Then then, Else _else) const //
+    -> _sndr<Sndr, Pred, Then, Else>;
+
+  template <class Pred, class Then, class Else>
+  USTDEX_HOST_DEVICE USTDEX_INLINE auto operator()(Pred pred, Then then, Else _else) const
+  {
+    return _closure<Pred, Then, Else>{
+      {static_cast<Pred&&>(pred), static_cast<Then&&>(then), static_cast<Else&&>(_else)}};
+  }
+};
+
+using conditional_t = _cond_t;
+USTDEX_DEVICE_CONSTANT constexpr conditional_t conditional{};
+
+template <class Sndr, class Pred, class Then, class Else>
+struct _cond_t::_sndr
+{
+  _cond_t _tag;
+  _cond_t::_data<Pred, Then, Else> _data;
+  Sndr _sndr;
+
+  template <class Rcvr>
+  USTDEX_HOST_DEVICE auto connect(Rcvr rcvr) && -> _opstate<Sndr, Rcvr, Pred, Then, Else>
+  {
+    return {
+      static_cast<Sndr&&>(_sndr), static_cast<Rcvr&&>(rcvr), static_cast<_cond_t::_data<Pred, Then, Else>&&>(_data)};
+  }
+
+  template <class Rcvr>
+  USTDEX_HOST_DEVICE auto connect(Rcvr rcvr) const& -> _opstate<Sndr const&, Rcvr, Pred, Then, Else>
+  {
+    return {_sndr, static_cast<Rcvr&&>(rcvr), static_cast<_cond_t::_data<Pred, Then, Else>&&>(_data)};
+  }
+
+  USTDEX_HOST_DEVICE env_of_t<Sndr> get_env() const noexcept
+  {
+    return ustdex::get_env(_sndr);
+  }
+};
+
+template <class Sndr, class Pred, class Then, class Else>
+USTDEX_HOST_DEVICE USTDEX_INLINE auto _cond_t::operator()(Sndr sndr, Pred pred, Then then, Else _else) const //
+  -> _sndr<Sndr, Pred, Then, Else>
+{
+  if constexpr (_is_non_dependent_sender<Sndr>)
+  {
+    using _completions = completion_signatures_of_t<_sndr<Sndr, Pred, Then, Else>>;
+    static_assert(_is_completion_signatures<_completions>);
+  }
+
+  return _sndr<Sndr, Pred, Then, Else>{
+    {}, {static_cast<Pred&&>(pred), static_cast<Then&&>(then), static_cast<Else&&>(_else)}, static_cast<Sndr&&>(sndr)};
+}
+
+template <class Pred, class Then, class Else>
+template <class Sndr>
+USTDEX_HOST_DEVICE USTDEX_INLINE auto _cond_t::_closure<Pred, Then, Else>::_mk_sender(Sndr&& sndr) //
+  -> _sndr<Sndr, Pred, Then, Else>
+{
+  if constexpr (_is_non_dependent_sender<Sndr>)
+  {
+    using _completions = completion_signatures_of_t<_sndr<Sndr, Pred, Then, Else>>;
+    static_assert(_is_completion_signatures<_completions>);
+  }
+
+  return _sndr<Sndr, Pred, Then, Else>{
+    {}, static_cast<_cond_t::_data<Pred, Then, Else>&&>(_data), static_cast<Sndr&&>(sndr)};
+}
+} // namespace ustdex

--- a/include/ustdex/detail/cpos.hpp
+++ b/include/ustdex/detail/cpos.hpp
@@ -132,6 +132,10 @@ USTDEX_DEVICE_CONSTANT constexpr struct connect_t
     noexcept(noexcept(static_cast<Sndr&&>(sndr).connect(static_cast<Rcvr&&>(rcvr))))
       -> decltype(static_cast<Sndr&&>(sndr).connect(static_cast<Rcvr&&>(rcvr)))
   {
+    // using opstate_t     = decltype(static_cast<Sndr&&>(sndr).connect(static_cast<Rcvr&&>(rcvr)));
+    // using completions_t = typename opstate_t::completion_signatures;
+    // static_assert(_is_completion_signatures<completions_t>);
+
     return static_cast<Sndr&&>(sndr).connect(static_cast<Rcvr&&>(rcvr));
   }
 } connect{};

--- a/include/ustdex/detail/just_from.hpp
+++ b/include/ustdex/detail/just_from.hpp
@@ -1,0 +1,146 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+#pragma once
+
+#include "completion_signatures.hpp"
+#include "config.hpp"
+#include "cpos.hpp"
+#include "rcvr_ref.hpp"
+#include "tuple.hpp"
+#include "utility.hpp"
+
+// Must be the last include
+#include "prologue.hpp"
+
+namespace USTDEX_NAMESPACE
+{
+// Forward declarations of the just* tag types:
+struct just_from_t;
+struct just_error_from_t;
+struct just_stopped_from_t;
+
+// Map from a disposition to the corresponding tag types:
+namespace _detail
+{
+template <_disposition_t, class Void = void>
+extern _undefined<Void> _just_from_tag;
+template <class Void>
+extern _fn_t<just_from_t>* _just_from_tag<_value, Void>;
+template <class Void>
+extern _fn_t<just_error_from_t>* _just_from_tag<_error, Void>;
+template <class Void>
+extern _fn_t<just_stopped_from_t>* _just_from_tag<_stopped, Void>;
+} // namespace _detail
+
+struct AN_ERROR_COMPLETION_MUST_HAVE_EXACTLY_ONE_ERROR_ARGUMENT;
+struct A_STOPPED_COMPLETION_MUST_HAVE_NO_ARGUMENTS;
+
+template <_disposition_t Disposition>
+struct _just_from
+{
+#ifndef __CUDACC__
+
+private:
+#endif
+
+  using JustTag = decltype(_detail::_just_from_tag<Disposition>());
+  using SetTag  = decltype(_detail::_set_tag<Disposition>());
+
+  using _diag_t = _mif<USTDEX_IS_SAME(SetTag, set_error_t),
+                       AN_ERROR_COMPLETION_MUST_HAVE_EXACTLY_ONE_ERROR_ARGUMENT,
+                       A_STOPPED_COMPLETION_MUST_HAVE_NO_ARGUMENTS>;
+
+  template <class... Ts>
+  using _error_t = ERROR<WHERE(IN_ALGORITHM, JustTag), WHAT(_diag_t), WITH_COMPLETION_SIGNATURE<SetTag(Ts...)>>;
+
+  struct _probe_fn
+  {
+    template <class... Ts>
+    auto operator()(Ts&&... ts) const noexcept
+      -> _mif<_is_valid_signature<SetTag(Ts...)>, completion_signatures<SetTag(Ts...)>, _error_t<Ts...>>;
+  };
+
+  template <class Rcvr = receiver_archetype>
+  struct _complete_fn
+  {
+    Rcvr& _rcvr;
+
+    template <class... Ts>
+    USTDEX_HOST_DEVICE auto operator()(Ts&&... ts) const noexcept
+    {
+      SetTag()(static_cast<Rcvr&>(_rcvr), static_cast<Ts&&>(ts)...);
+    }
+  };
+
+  template <class Rcvr, class Fn>
+  struct _opstate
+  {
+    using operation_state_concept = operation_state_t;
+    using completion_signatures   = _call_result_t<Fn, _probe_fn>;
+    static_assert(_is_completion_signatures<completion_signatures>);
+
+    Rcvr _rcvr;
+    Fn _fn;
+
+    USTDEX_HOST_DEVICE void start() & noexcept
+    {
+      static_cast<Fn&&>(_fn)(_complete_fn<Rcvr>{_rcvr});
+    }
+  };
+
+  template <class Fn>
+  struct _sndr_t
+  {
+    using sender_concept = sender_t;
+
+    USTDEX_NO_UNIQUE_ADDRESS JustTag _tag;
+    Fn _fn;
+
+    template <class Rcvr>
+    USTDEX_HOST_DEVICE _opstate<Rcvr, Fn> connect(Rcvr rcvr) && //
+      noexcept(_nothrow_decay_copyable<Rcvr, Fn>)
+    {
+      return _opstate<Rcvr, Fn>{static_cast<Rcvr&&>(rcvr), static_cast<Fn&&>(_fn)};
+    }
+
+    template <class Rcvr>
+    USTDEX_HOST_DEVICE _opstate<Rcvr, Fn> connect(Rcvr rcvr) const& //
+      noexcept(_nothrow_decay_copyable<Rcvr, Fn const&>)
+    {
+      return _opstate<Rcvr, Fn>{static_cast<Rcvr&&>(rcvr), _fn};
+    }
+  };
+
+public:
+  template <class Fn>
+  USTDEX_INLINE USTDEX_HOST_DEVICE auto operator()(Fn fn) const noexcept
+  {
+    using _completions = _call_result_t<Fn, _probe_fn>;
+    static_assert(_is_completion_signatures<_completions>,
+                  "The function passed to just_from must return an instance of a specialization of "
+                  "completion_signatures<>.");
+    return _sndr_t<Fn>{{}, static_cast<Fn&&>(fn)};
+  }
+};
+
+USTDEX_DEVICE_CONSTANT constexpr struct just_from_t : _just_from<_value>
+{
+} just_from{};
+
+USTDEX_DEVICE_CONSTANT constexpr struct just_error_from_t : _just_from<_error>
+{
+} just_error_from{};
+
+USTDEX_DEVICE_CONSTANT constexpr struct just_stopped_from_t : _just_from<_stopped>
+{
+} just_stopped_from{};
+} // namespace USTDEX_NAMESPACE
+
+#include "epilogue.hpp"

--- a/include/ustdex/detail/let_value.hpp
+++ b/include/ustdex/detail/let_value.hpp
@@ -250,9 +250,17 @@ private:
     Fn _fn;
 
     template <class Sndr>
-    USTDEX_HOST_DEVICE USTDEX_INLINE friend auto operator|(Sndr sndr, _closure_t&& _self)
+    USTDEX_HOST_DEVICE USTDEX_INLINE auto operator()(Sndr sndr) const //
+      -> _call_result_t<LetTag, Sndr, Fn>
     {
-      return LetTag()(static_cast<Sndr&&>(sndr), static_cast<Fn&&>(_self._fn));
+      return LetTag()(static_cast<Sndr&&>(sndr), _fn);
+    }
+
+    template <class Sndr>
+    USTDEX_HOST_DEVICE USTDEX_INLINE friend auto operator|(Sndr sndr, const _closure_t& _self) //
+      -> _call_result_t<LetTag, Sndr, Fn>
+    {
+      return LetTag()(static_cast<Sndr&&>(sndr), _self._fn);
     }
   };
 

--- a/include/ustdex/detail/meta.hpp
+++ b/include/ustdex/detail/meta.hpp
@@ -242,6 +242,9 @@ struct WITH_QUERY;
 
 struct WITH_ENVIRONMENT;
 
+template <class>
+struct WITH_COMPLETION_SIGNATURE;
+
 struct FUNCTION_IS_NOT_CALLABLE;
 
 struct UNKNOWN;

--- a/include/ustdex/detail/sync_wait.hpp
+++ b/include/ustdex/detail/sync_wait.hpp
@@ -168,8 +168,8 @@ public:
       _state_t<Sndr> state{&result};
 
       // Launch the sender with a continuation that will fill in a variant
-      auto opstate = connect(static_cast<Sndr&&>(sndr), _rcvr_t{&state});
-      start(opstate);
+      auto opstate = ustdex::connect(static_cast<Sndr&&>(sndr), _rcvr_t{&state});
+      ustdex::start(opstate);
 
       // Wait for the variant to be filled in, and process any work that
       // may be delegated to this thread.

--- a/include/ustdex/ustdex.hpp
+++ b/include/ustdex/ustdex.hpp
@@ -16,10 +16,12 @@
 #pragma once
 
 #include "detail/basic_sender.hpp"
+#include "detail/conditional.hpp"
 #include "detail/config.hpp"
 #include "detail/continue_on.hpp"
 #include "detail/cpos.hpp"
 #include "detail/just.hpp"
+#include "detail/just_from.hpp"
 #include "detail/let_value.hpp"
 #include "detail/queries.hpp"
 #include "detail/read_env.hpp"

--- a/tests/test_conditional.cpp
+++ b/tests/test_conditional.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Include this first
+#include <ustdex/ustdex.hpp>
+
+// Then include the test helpers
+#include "common/catch2.hpp"
+#include "common/checked_receiver.hpp"
+#include "common/utility.hpp"
+
+namespace ex = USTDEX_NAMESPACE;
+
+namespace
+{
+TEST_CASE("simple use of conditional runs exactly one of the two closures", "[adaptors][conditional]")
+{
+  for (int i = 42; i < 44; ++i)
+  {
+    bool even{false};
+    bool odd{false};
+
+    auto sndr1 =
+      ex::just(i)
+      | ex::conditional(
+        [](int i) {
+          return i % 2 == 0;
+        },
+        ex::then([&](int) {
+          even = true;
+        }),
+        ex::then([&](int) {
+          odd = true;
+        }));
+
+    check_value_types<types<>>(sndr1);
+    check_error_types<std::exception_ptr>(sndr1);
+    check_sends_stopped<false>(sndr1);
+
+    auto op = ex::connect(std::move(sndr1), checked_value_receiver<>{});
+    ex::start(op);
+
+    CHECK(even == (i % 2 == 0));
+    CHECK(odd == (i % 2 == 1));
+  }
+}
+
+} // namespace


### PR DESCRIPTION
drive-by: fix a bug in the computation of the `then` sender's completions